### PR TITLE
Fix projector alignment not calculating correct center position for some blocks

### DIFF
--- a/Data/Scripts/ProjectorPreview/ProjectorAligner.cs
+++ b/Data/Scripts/ProjectorPreview/ProjectorAligner.cs
@@ -45,13 +45,13 @@ namespace Digi.ProjectorPreview
         /// </summary>
         /// <param name="firstBlockCenter">center of the first block</param>
         /// <param name="projectorCenter">center of the projected projector</param>
-        /// <param name="orojectorOrientation">orientation of the projected projector</param>
+        /// <param name="projectorOrientation">orientation of the projected projector</param>
         /// <param name="projectionOffset">calculated offset</param>
         /// <param name="projectionRotation">calculated rotation</param>
-        public static void Align(Vector3I firstBlockCenter, Vector3I projectorCenter, MyBlockOrientation orojectorOrientation,
+        public static void Align(Vector3I firstBlockCenter, Vector3I projectorCenter, MyBlockOrientation projectorOrientation,
             out Vector3I projectionOffset, out Vector3I projectionRotation)
         {
-            Vector3I targetRotate = RotationLookup[orojectorOrientation];
+            Vector3I targetRotate = RotationLookup[projectorOrientation];
             Vector3I offsetVector = -firstBlockCenter + projectorCenter;
 
             Vector3 r = targetRotate * MathHelper.ToRadians(90f);

--- a/Data/Scripts/ProjectorPreview/ProjectorBlock.cs
+++ b/Data/Scripts/ProjectorPreview/ProjectorBlock.cs
@@ -499,7 +499,7 @@ namespace Digi.ProjectorPreview
             Vector3I refBlockCenter = CalculateBlockCenterInGrid(refBlock);
             Vector3I projectorCenter = CalculateBlockCenterInGrid(projectedProjector);
 
-            AlignProjection(refBlockCenter, projectorCenter, projectedProjector.Orientation); // TODO: test if works...
+            AlignProjection(refBlockCenter, projectorCenter, projectedProjector.Orientation);
         }
 
         static Vector3I CalculateBlockCenterInOB(MyObjectBuilder_CubeBlock block)


### PR DESCRIPTION
Hi again, I noticed an issue with projection alignment on one of my ships and figured out how to reproduce and what went wrong.

Steps to reproduce:

1. Place a block with a clear direction, e.g. connector.
2. Place new multi-block block with non-center center such as an o2/h2 generator with a different orientation than the first block.
3. Place a battery and a projector
4. Create a blueprint
5. Delete the created cached blueprint bp.sbcB5 
6. Open bp.sbc in a text editor, and move the multi-block MyObjectBuilder_CubeBlock tag to the first in the CubeBlocks list
7. Spawn the blueprint in
8. Try "Load this ship..." and "Align Projection" options, both should fail to properly align the position. See screenshot below.

![image](https://github.com/THDigi/ProjectorPreview/assets/147366/26391dfa-bb69-47e7-917a-ab253969dc60)

Digging through the code I figured out the bug and how to fix it. The Center property from MyCubeBlockDefinition is the vector from Min to center, but on a block before rotation. The Min we are given is the min corner **after** rotation and it might not correspond to a min corner before rotation, so there's no way to get the center coordinate using only the given Min vector.

The fix is to do a reverse rotation of all corners of the block, figure out which corner is the actual min one, calculate the center using that one, then apply the original rotation to the center to get the rotated center coordinate.

For MyObjectBuilder_CubeBlock blocks where no max is given we can't know the corners of the block, so I calculate the possible corners using the size property for the definition, find the correct max corner, and repeat the above steps.

Tested with various orientations for reference blocks.